### PR TITLE
PromisedScene: always try to match titles

### DIFF
--- a/plugins/PromisedScene/README.md
+++ b/plugins/PromisedScene/README.md
@@ -4,6 +4,20 @@ by Ch00nassid a.k.a: DGs.Ch00, leadwolf
 
 Ask questions and make sure scene parsing is correct
 
+### Documentation
+
+### Details
+
+The plugin will search TPDB with one of scene's actors, the studio (these two must have the relevant "parse" args enabled), the date in the scene path and the title (if `useTitleInSearch` is enabled).  
+With the results from TPDB, it then tries to match their titles to the title of the scene. If a match is found, it will be returned.  
+If no match is found, and `manualTouch` is enabled, you will be able to interactively search or enter the scene's details, until you confirm the result or quit the process.
+
+### Tips
+
+- When running without `manualTouch`, but you still want to search TPDB with a specific string, you can enable `useTitleInSearch`, change the scene's name and then run the plugin.
+
+- If TPDB only returns 1 result and  the plugin does not match the titles but you are sure they are the same , you can enable `alwaysUseSingleResult` to override the matching process.
+
 ### Arguments
 
 | Name                    | Type    | Required | Description                                                                                                                                       |
@@ -12,7 +26,7 @@ Ask questions and make sure scene parsing is correct
 | alwaysUseSingleResult   | Boolean | false    | When searching TPDB, if there is **only** 1 result, even if its title **doesn't** match the searched title, if should return that data            |
 | parseActor              | Boolean | true     | Try to find the Actor name in your database within the scenePath string                                                                           |
 | parseStudio             | Boolean | true     | Try to find the Studio name in your database within the scenePath string                                                                          |
-| manualTouch             | Boolean | true     | If true, will ask questions to manually answer and fill in details.  If false, will agressivly search and automatically populate the vault.       |
+| manualTouch             | Boolean | true     | If true, will allow you to answer questions to manually enter scene data, manually search TPDB, confirm the final result                          |
 | sceneDuplicationCheck   | Boolean | true     | Will notify you of a possible duplicate title that is being imported.  Will not currently stop / correct anything                                 |
 | source_settings.actors  | String  | true     | finds the DB file for Actors to determine which actors are currently in your collection                                                           |
 | source_settings.studios | String  | true     | finds the DB file for Studios to determine which Studios are currently in your collection                                                         |

--- a/plugins/PromisedScene/README.md
+++ b/plugins/PromisedScene/README.md
@@ -9,6 +9,7 @@ Ask questions and make sure scene parsing is correct
 | Name                    | Type    | Required | Description                                                                                                                                       |
 | ----------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | useTitleInSearch        | Boolean | false    | When searching TPDB: in auto search, if should use existing scene title. In manual user search, if should prompt user for title and use in search |
+| alwaysUseSingleResult   | Boolean | false    | When searching TPDB, if there is **only** 1 result, even if its title **doesn't** match the searched title, if should return that data            |
 | parseActor              | Boolean | true     | Try to find the Actor name in your database within the scenePath string                                                                           |
 | parseStudio             | Boolean | true     | Try to find the Studio name in your database within the scenePath string                                                                          |
 | manualTouch             | Boolean | true     | If true, will ask questions to manually answer and fill in details.  If false, will agressivly search and automatically populate the vault.       |
@@ -29,6 +30,7 @@ Ask questions and make sure scene parsing is correct
         "path": "./plugins/PromisedScene/main.ts",
         "args": {
           "useTitleInSearch": false,
+          "alwaysUseSingleResult": false,
           "parseActor": true,
           "parseStudio": true,
           "manualTouch": true,
@@ -63,6 +65,7 @@ plugins:
       path: ./plugins/PromisedScene/main.ts
       args:
         useTitleInSearch: false
+        alwaysUseSingleResult: false
         parseActor: true
         parseStudio: true
         manualTouch: true

--- a/plugins/PromisedScene/docs.md
+++ b/plugins/PromisedScene/docs.md
@@ -1,0 +1,11 @@
+### Details
+
+The plugin will search TPDB with one of scene's actors, the studio (these two must have the relevant "parse" args enabled), the date in the scene path and the title (if `useTitleInSearch` is enabled).  
+With the results from TPDB, it then tries to match their titles to the title of the scene. If a match is found, it will be returned.  
+If no match is found, and `manualTouch` is enabled, you will be able to interactively search or enter the scene's details, until you confirm the result or quit the process.
+
+### Tips
+
+- When running without `manualTouch`, but you still want to search TPDB with a specific string, you can enable `useTitleInSearch`, change the scene's name and then run the plugin.
+
+- If TPDB only returns 1 result and  the plugin does not match the titles but you are sure they are the same , you can enable `alwaysUseSingleResult` to override the matching process.

--- a/plugins/PromisedScene/info.json
+++ b/plugins/PromisedScene/info.json
@@ -13,6 +13,13 @@
       "description": "When searching TPDB: in auto search, if should use existing scene title. In manual user search, if should prompt user for title and use in search"
     },
     {
+      "name": "alwaysUseSingleResult",
+      "type": "Boolean",
+      "required": false,
+      "default": false,
+      "description": "When searching TPDB, if there is **only** 1 result, even if its title **doesn't** match the searched title, if should return that data"
+    },
+    {
       "name": "parseActor",
       "type": "Boolean",
       "required": true,

--- a/plugins/PromisedScene/info.json
+++ b/plugins/PromisedScene/info.json
@@ -38,7 +38,7 @@
       "type": "Boolean",
       "required": true,
       "default": true,
-      "description": "If true, will ask questions to manually answer and fill in details.  If false, will agressivly search and automatically populate the vault."
+      "description": "If true, will allow you to answer questions to manually enter scene data, manually search TPDB, confirm the final result"
     },
     {
       "name": "sceneDuplicationCheck",

--- a/plugins/PromisedScene/parse.ts
+++ b/plugins/PromisedScene/parse.ts
@@ -65,36 +65,31 @@ export const parseSceneActor = (ctx: MyContext): string | null => {
     });
 
   let actorHighScore = 5000;
-  if (allDbActors.length && Array.isArray(allDbActors)) {
-    allDbActors.forEach((person) => {
-      // This is a function that will see how many differences it will take to make the string match.
-      // The lowest amount of changes means that it is probably the closest match to what we need.
-      // lowest score wins :)
-      let foundAnAlias = false;
-      if (person.includes("alias:")) {
-        person = person.toString().replace("alias:", "").trim();
-        foundAnAlias = true;
-      }
-      const found = levenshtein(person.toString().toLowerCase(), cleanScenePath);
 
-      if (found < actorHighScore) {
-        actorHighScore = found;
+  allDbActors.forEach((person) => {
+    // This is a function that will see how many differences it will take to make the string match.
+    // The lowest amount of changes means that it is probably the closest match to what we need.
+    // lowest score wins :)
+    let foundAnAlias = false;
+    if (person.includes("alias:")) {
+      person = person.toString().replace("alias:", "").trim();
+      foundAnAlias = true;
+    }
+    const found = levenshtein(person.toString().toLowerCase(), cleanScenePath);
 
-        parsedDbActor = person;
-      }
-      if (foundAnAlias) {
-        ctx.$log(`[PDS] PARSE: SUCCESS Found Actor-Alias: ${JSON.stringify(person)}`);
-      } else {
-        ctx.$log(`[PDS] PARSE: SUCCESS Found Actor: ${JSON.stringify(person)}`);
-      }
-    });
-    ctx.$log(
-      `[PDS] PARSE: End of parse. Using "best match" Actor For Search: ${JSON.stringify(
-        parsedDbActor
-      )}`
-    );
-  }
+    if (found < actorHighScore) {
+      actorHighScore = found;
 
+      parsedDbActor = person;
+    }
+    if (foundAnAlias) {
+      ctx.$log(`[PDS] PARSE: SUCCESS Found Actor-Alias: ${JSON.stringify(person)}`);
+    } else {
+      ctx.$log(`[PDS] PARSE: SUCCESS Found Actor: ${JSON.stringify(person)}`);
+    }
+  });
+
+  ctx.$log(`[PDS] PARSE:\tUsing "best match" Actor For Search: ${JSON.stringify(parsedDbActor)}`);
   return parsedDbActor;
 };
 
@@ -166,41 +161,36 @@ export const parseSceneStudio = (ctx: MyContext): string | null => {
         }
       });
     });
-  // this is a debug option to se see how many studios were found by just doing a simple regex
-  // $log(GettingStudio);
+
   let studioHighScore = 5000;
-  if (allDbStudios.length && Array.isArray(allDbStudios)) {
-    let foundStudioAnAlias = false;
-    let instanceFoundStudioAnAlias = false;
-    allDbStudios.forEach((stud) => {
-      if (stud.includes("alias:")) {
-        stud = stud.toString().replace("alias:", "").trim();
-        instanceFoundStudioAnAlias = true;
-      }
+  let foundStudioAnAlias = false;
+  let instanceFoundStudioAnAlias = false;
 
-      // This is a function that will see how many differences it will take to make the string match.
-      // The lowest amount of changes means that it is probably the closest match to what we need.
-      // lowest score wins :)
-      const found = levenshtein(stud.toString().toLowerCase(), cleanScenePath);
+  allDbStudios.forEach((stud) => {
+    if (stud.includes("alias:")) {
+      stud = stud.toString().replace("alias:", "").trim();
+      instanceFoundStudioAnAlias = true;
+    }
 
-      if (found < studioHighScore) {
-        studioHighScore = found;
+    // This is a function that will see how many differences it will take to make the string match.
+    // The lowest amount of changes means that it is probably the closest match to what we need.
+    // lowest score wins :)
+    const found = levenshtein(stud.toString().toLowerCase(), cleanScenePath);
 
-        parsedDbStudio = stud;
-        foundStudioAnAlias = instanceFoundStudioAnAlias;
-      }
-      if (foundStudioAnAlias) {
-        ctx.$log(`[PDS] PARSE:\tSUCCESS: Found Studio-Alias: ${JSON.stringify(parsedDbStudio)}`);
-      } else {
-        ctx.$log(`[PDS] PARSE:\tSUCCESS: Found Studio: ${JSON.stringify(parsedDbStudio)}`);
-      }
-    });
+    if (found < studioHighScore) {
+      studioHighScore = found;
 
-    ctx.$log(
-      `[PDS] PARSE:\tUsing "best match" Studio For Search: ${JSON.stringify(parsedDbStudio)}`
-    );
-  }
+      parsedDbStudio = stud;
+      foundStudioAnAlias = instanceFoundStudioAnAlias;
+    }
+    if (foundStudioAnAlias) {
+      ctx.$log(`[PDS] PARSE:\tSUCCESS: Found Studio-Alias: ${JSON.stringify(parsedDbStudio)}`);
+    } else {
+      ctx.$log(`[PDS] PARSE:\tSUCCESS: Found Studio: ${JSON.stringify(parsedDbStudio)}`);
+    }
+  });
 
+  ctx.$log(`[PDS] PARSE:\tUsing "best match" Studio For Search: ${JSON.stringify(parsedDbStudio)}`);
   return parsedDbStudio;
 };
 

--- a/plugins/PromisedScene/test/index.spec.js
+++ b/plugins/PromisedScene/test/index.spec.js
@@ -4,7 +4,7 @@ import { manualTouchChoices } from "../util";
 const context = require("../../../context");
 const { expect } = require("chai");
 
-describe("PromisedScene", () => {
+describe.only("PromisedScene", () => {
   describe("Handle all of the errors properly.", () => {
     it("Should fail with error:  Plugin used for unsupported event", async () => {
       let errord = false;

--- a/plugins/PromisedScene/test/index.spec.js
+++ b/plugins/PromisedScene/test/index.spec.js
@@ -4,7 +4,7 @@ import { manualTouchChoices } from "../util";
 const context = require("../../../context");
 const { expect } = require("chai");
 
-describe.only("PromisedScene", () => {
+describe("PromisedScene", () => {
   describe("Handle all of the errors properly.", () => {
     it("Should fail with error:  Plugin used for unsupported event", async () => {
       let errord = false;
@@ -702,6 +702,53 @@ describe.only("PromisedScene", () => {
       expect(result.actors).to.be.a("Array");
       expect(result.studio).to.equal("BANG BROS 18");
     });
+
+    it("with db, alwaysUseSingleResult, extra search -- Should find with correct answers", async () => {
+      const result = await plugin({
+        ...context,
+        event: "sceneCreated",
+        args: {
+          alwaysUseSingleResult: true,
+          manualTouch: true,
+          sceneDuplicationCheck: true,
+          parseActor: true,
+          parseStudio: true,
+          source_settings: {
+            actors: "./plugins/PromisedScene/test/fixtures/actorsUnPopulated.db",
+            scenes: "./plugins/PromisedScene/test/fixtures/scenesUnPopulated.db",
+            studios: "./plugins/PromisedScene/test/fixtures/studiosPopulated.db",
+          },
+        },
+        sceneName: "fake scene name",
+        scenePath: "Z:\\Keep\\test\\fake scene name",
+        testMode: {
+          correctImportInfo: "y",
+          questionAnswers: {
+            enterInfoSearch: manualTouchChoices.SEARCH,
+            enterMovie: "",
+            enterOneActorName: "",
+            enterSceneDate: "",
+            enterSceneTitle: "",
+            enterStudioName: "",
+            manualActors: "",
+            manualDescription: "",
+            movieTitle: "",
+            multipleChoice: "",
+            extra: "Mia Malkova NEW SENSATIONS 2013.10.10",
+          },
+          testSiteUnavailable: false,
+          status: true,
+        },
+      });
+      expect(result).to.be.an("object");
+      expect(result.description).to.equal(
+        "Mia Malkova's back and more flexible more than ever. She is looking fine and is extremely horny for some sweet stud lovin'. Cum watch Mia Malkova work this hard cock to explosion of warm man chowder all across her face!"
+      );
+      expect(result.releaseDate).to.be.a("number");
+      expect(result.thumbnail).to.be.a("string");
+      expect(result.actors).to.be.a("Array");
+      expect(result.studio).to.equal("New Sensations");
+    });
   });
 
   describe("When UnPopulated Databases exist...", () => {
@@ -859,6 +906,53 @@ describe.only("PromisedScene", () => {
       expect(result.actors).to.be.a("Array");
       expect(result.studio).to.equal("NEW SENSATIONS");
       expect(result.movie).to.equal("So Young So Sexy P.O.V. #8");
+    });
+
+    it("no db, alwaysUseSingleResult, extra search -- Should find with correct answers", async () => {
+      const result = await plugin({
+        ...context,
+        event: "sceneCreated",
+        args: {
+          alwaysUseSingleResult: true,
+          manualTouch: true,
+          sceneDuplicationCheck: true,
+          parseActor: true,
+          parseStudio: true,
+          source_settings: {
+            actors: "./plugins/PromisedScene/test/fixtures/actorsUnPopulated.db",
+            scenes: "./plugins/PromisedScene/test/fixtures/scenesUnPopulated.db",
+            studios: "./plugins/PromisedScene/test/fixtures/studiosPopulated.db",
+          },
+        },
+        sceneName: "fake scene name",
+        scenePath: "Z:\\Keep\\test\\fake scene name",
+        testMode: {
+          correctImportInfo: "y",
+          questionAnswers: {
+            enterInfoSearch: manualTouchChoices.SEARCH,
+            enterMovie: "",
+            enterOneActorName: "",
+            enterSceneDate: "",
+            enterSceneTitle: "",
+            enterStudioName: "",
+            manualActors: "",
+            manualDescription: "",
+            movieTitle: "",
+            multipleChoice: "",
+            extra: "Mia Malkova NEW SENSATIONS 2013.10.10",
+          },
+          testSiteUnavailable: false,
+          status: true,
+        },
+      });
+      expect(result).to.be.an("object");
+      expect(result.description).to.equal(
+        "Mia Malkova's back and more flexible more than ever. She is looking fine and is extremely horny for some sweet stud lovin'. Cum watch Mia Malkova work this hard cock to explosion of warm man chowder all across her face!"
+      );
+      expect(result.releaseDate).to.be.a("number");
+      expect(result.thumbnail).to.be.a("string");
+      expect(result.actors).to.be.a("Array");
+      expect(result.studio).to.equal("New Sensations");
     });
   });
 

--- a/plugins/PromisedScene/types.ts
+++ b/plugins/PromisedScene/types.ts
@@ -197,6 +197,7 @@ export interface MyContext extends SceneContext {
     parseStudio: boolean;
     manualTouch: boolean;
     sceneDuplicationCheck: boolean;
+    alwaysUseSingleResult: boolean;
     source_settings: {
       actors: string;
       studios: string;

--- a/plugins/PromisedScene/util.ts
+++ b/plugins/PromisedScene/util.ts
@@ -209,7 +209,11 @@ export const matchSceneResultToSearch = (
 
       if (searchedTitle !== undefined) {
         if (matchTitleRegex.test(searchedTitle)) {
-          ctx.$log(`[PDS] MATCH:\t\tSUCCESS: ${JSON.stringify(scene.title)} did match`);
+          ctx.$log(
+            `[PDS] MATCH:\t\tSUCCESS: ${JSON.stringify(searchedTitle)} did match to ${JSON.stringify(
+              matchTitle
+            )}`
+          );
           return scene;
         }
       }

--- a/plugins/PromisedScene/util.ts
+++ b/plugins/PromisedScene/util.ts
@@ -167,11 +167,11 @@ export const matchSceneResultToSearch = (
   knownActors: string[],
   studio: string | undefined
 ): SceneResult.SceneData | null => {
-  ctx.$log(`[PDS] SRCH: ${sceneList.length} results found`);
+  ctx.$log(`[PDS] MATCH: ${sceneList.length} results found`);
 
   for (const scene of sceneList) {
     ctx.$log(
-      `[PDS] SRCH: Trying to match TPD title: ${JSON.stringify(
+      `[PDS] MATCH:\tTrying to match TPD title: ${JSON.stringify(
         scene.title
       )} --with--> ${JSON.stringify(ctx.sceneName)}`
     );
@@ -209,11 +209,14 @@ export const matchSceneResultToSearch = (
 
       if (searchedTitle !== undefined) {
         if (matchTitleRegex.test(searchedTitle)) {
+          ctx.$log(`[PDS] MATCH:\t\tSUCCESS: ${JSON.stringify(scene.title)} did match`);
           return scene;
         }
       }
     }
   }
+
+  ctx.$log(`[PDS] MATCH:\tERR: did not find any match`);
 
   return null;
 };

--- a/plugins/PromisedScene/util.ts
+++ b/plugins/PromisedScene/util.ts
@@ -16,10 +16,10 @@ export const isPositiveAnswer = (answer = ""): boolean =>
   ["y", "yes"].includes(answer.toLowerCase());
 
 /**
- * @param timestamp - Time string to be converted to timestamp
- * @returns TODO:
+ * @param timestamp - Timestamp to be converted to date
+ * @returns a human friendly date string in YYYY-MM-DD
  */
-export function timeConverter(timestamp: number) {
+export function timestampToString(timestamp: number) {
   const dateNotFormatted = new Date(timestamp);
 
   let formattedString = dateNotFormatted.getFullYear() + "-";
@@ -170,6 +170,12 @@ export const matchSceneResultToSearch = (
   ctx.$log(`[PDS] SRCH: ${sceneList.length} results found`);
 
   for (const scene of sceneList) {
+    ctx.$log(
+      `[PDS] SRCH: Trying to match TPD title: ${JSON.stringify(
+        scene.title
+      )} --with--> ${JSON.stringify(ctx.sceneName)}`
+    );
+
     // It is better to search just the title.  We already have the actor and studio.
     let searchedTitle = stripStr(ctx.sceneName).toLowerCase();
 
@@ -188,7 +194,6 @@ export const matchSceneResultToSearch = (
     }
 
     // lets remove the Studio from the scenename and the searched title -- We should already know this
-    //$log("removing studio name from comparison strings...")
     if (studio) {
       searchedTitle = searchedTitle.replace(studio.toLowerCase(), "");
       searchedTitle = searchedTitle.replace(studio.toLowerCase().replace(" ", ""), "");
@@ -200,12 +205,6 @@ export const matchSceneResultToSearch = (
     searchedTitle = searchedTitle.trim();
 
     if (matchTitle) {
-      ctx.$log(
-        `[PDS] SRCH: Trying to match TPD title: ${JSON.stringify(
-          matchTitle
-        )} --with--> ${JSON.stringify(searchedTitle)}`
-      );
-
       const matchTitleRegex = new RegExp(matchTitle, "i");
 
       if (searchedTitle !== undefined) {


### PR DESCRIPTION
- always try to match tpdb titles to scene name
- add `alwaysUseSingleResult` arg
- - This option is for people who do not use "manualTouch". If the plugin does not match a tpdb title to the scene name, it allows the result to be used anyways